### PR TITLE
feat: remove Node.js v8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ matrix:
       env: LINT=true COVERAGE=true TEST=true
     - node_js: '10'
       env: TEST=true
-    - node_js: '8'
-      env: TEST=true
 before_install:
   - npm install -g npm
   - npm --version

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
   "directories": {
     "test": "test"
   },
+  "engines": {
+    "node": "10 || 12 || >=14"
+  },
   "scripts": {
     "lint": "eslint *.js test/*.js",
     "tests-only": "tape test/index.js",


### PR DESCRIPTION
BREAKING CHANGE: Node.js v10 is now the minimum supported version of
Node.js.