### PR TITLE
feat(ci): remove Node.js v10, add Node.js v16

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [10, 12, 14]
+        node-version: [12, 14, 16]
         os: [ubuntu-latest]
     steps:
     - name: Node.js ${{ matrix.node-version }}

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2013–2014 Kenan Yildirim <http://kenany.me/>
+Copyright 2013–2021 Kenan Yildirim <https://kenany.me/>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": "KenanY/lucas-lehmer-test",
   "license": "MIT",
-  "author": "Kenan Yildirim <kenan@kenany.me> (http://kenany.me/)",
+  "author": "Kenan Yildirim <kenan@kenany.me> (https://kenany.me/)",
   "main": "index.js",
   "files": [
     "index.js",
@@ -20,7 +20,7 @@
     "test": "test"
   },
   "engines": {
-    "node": "10 || 12 || >=14"
+    "node": "12 || 14 || >=16"
   },
   "scripts": {
     "lint": "eslint *.js test/*.js",


### PR DESCRIPTION
BREAKING CHANGE: Node.js v10 is no longer supported. The minimum
supported version of Node.js is now v12.