### PR TITLE
feat: drop Node.js v12 support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text=auto
+* text=auto eol=lf

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,3 +1,4 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["local>kenany/renovate-config"]
 }

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [12, 14, 16]
+        node-version: [14, 16, 18]
         os: [ubuntu-latest]
     steps:
     - name: Node.js ${{ matrix.node-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 *.log
+.nyc_output

--- a/index.js
+++ b/index.js
@@ -1,5 +1,9 @@
-var bigInt = require('big-integer');
+const bigInt = require('big-integer');
 
+/**
+ * @param {number} p
+ * @returns {boolean}
+ */
 module.exports = function(p) {
   p = bigInt(p);
   if (p.equals(2)) {
@@ -9,10 +13,10 @@ module.exports = function(p) {
   //   return false;
   // }
 
-  var s = bigInt(4);
-  var M = bigInt(2).pow(p).minus(1);
+  let s = bigInt(4);
+  const M = bigInt(2).pow(p).minus(1);
 
-  var index = bigInt(-1);
+  let index = bigInt(-1);
   while ((index = index.next()).lesser(p.minus(2))) {
     s = s.pow(2).minus(2).mod(M);
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "test"
   },
   "engines": {
-    "node": "12 || 14 || >=16"
+    "node": "14 || 16 || >=18"
   },
   "scripts": {
     "lint": "eslint *.js test/*.js",

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
-var test = require('tape');
-var isFunction = require('lodash.isfunction');
+const test = require('tape');
+const isFunction = require('lodash.isfunction');
 
-var lucasLehmerTest = require('../');
+const lucasLehmerTest = require('../');
 
 test('exports a function', function(t) {
   t.plan(1);
@@ -9,7 +9,7 @@ test('exports a function', function(t) {
 });
 
 test('works', function(t) {
-  var TEST_ARRAY = [
+  const TEST_ARRAY = [
     [2, true],
     [3, true],
     [4, false],


### PR DESCRIPTION
BREAKING CHANGE: Node.js v12 is no longer supported.